### PR TITLE
Added almostEqual() assert

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -167,6 +167,24 @@
     return this;
   };
 
+
+  /**
+   * Checks if the obj almost equals another, optionally providing a max absolute difference.
+   *
+   * @api public
+   */
+  Assertion.prototype.approximately =
+  Assertion.prototype.approximatelyEqual =
+  Assertion.prototype.almostEqual = function (obj, maxDiff) {
+	var allowedDiff = maxDiff;
+	if(typeof(allowedDiff)=="undefined") {
+	  allowedDiff = 0.0001;
+	}
+	allowedDiff = Math.abs(allowedDiff);
+
+	return this.within(obj - allowedDiff, obj + allowedDiff);
+  };
+
   /**
    * Checks if the obj sortof equals another.
    *

--- a/test/expect.js
+++ b/test/expect.js
@@ -183,6 +183,29 @@ describe('expect', function () {
     }, "expected 10 to be within 50..100");
   });
 
+  it('should test almostEqual(n)', function () {
+    expect(5.00001).to.almostEqual(5);
+	expect(4.99999).to.almostEqual(5);
+    expect(5.1).to.not.almostEqual(5);
+
+	expect(-5.00001).to.almostEqual(-5);
+    expect(-5.00001).to.not.almostEqual(5);
+
+	expect(5.1).to.almostEqual(5, 0.2);
+	expect(4.5).to.not.almostEqual(5, 0.2);
+	
+	expect(5.1).to.almostEqual(5, -0.2);
+	expect(4.9).to.almostEqual(5, -0.2);
+
+    err(function () {
+      expect(5.1).to.almostEqual(5);
+    }, "expected 5.1 to be within 4.9999..5.0001");
+
+    err(function () {
+      expect(4.9).to.almostEqual(5);
+    }, "expected 4.9 to be within 4.9999..5.0001");
+  });
+
   it('should test above(n)', function () {
     expect(5).to.be.above(2);
     expect(5).to.be.greaterThan(2);


### PR DESCRIPTION
Added almostEqual() assert for checking for near-equality, useful for testing results of numeric calculations with precision rounding errors. Test code becomes much more compact than when using within() assert directly.

Also wrote some some unit tests that should cover most potential bugs if not all.
