### PR TITLE
expect({ a: undefined }).to.have.property('a') now passes.

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -310,8 +310,15 @@
         throw new Error(i(this.obj) + ' has no property ' + i(name));
       }
     } else {
+      var hasProp;
+      try {
+        hasProp = name in this.obj
+      } catch (e) {
+        hasProp = undefined !== this.obj[name]
+      }
+      
       this.assert(
-          undefined !== this.obj[name]
+          hasProp
         , 'expected ' + i(this.obj) + ' to have a property ' + i(name)
         , 'expected ' + i(this.obj) + ' to not have a property ' + i(name));
     }

--- a/test/expect.js
+++ b/test/expect.js
@@ -283,14 +283,20 @@ describe('expect', function () {
   it('should test property(name)', function () {
     expect('test').to.have.property('length');
     expect(4).to.not.have.property('length');
+    expect({ length: undefined }).to.have.property('length');
 
     err(function () {
       expect('asd').to.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
+    
+    err(function () {
+      expect({ length: undefined }).to.not.have.property('length');
+    }, "expected { length: undefined } to not have a property 'length'");
   });
 
   it('should test property(name, val)', function () {
     expect('test').to.have.property('length', 4);
+    expect({ length: undefined }).to.have.property('length', undefined);
 
     err(function () {
       expect('asd').to.have.property('length', 4);
@@ -303,6 +309,10 @@ describe('expect', function () {
     err(function () {
       expect('asd').to.not.have.property('foo', 3);
     }, "'asd' has no property 'foo'");
+    
+    err(function () {
+      expect({ length: undefined }).to.not.have.property('length', undefined);
+    }, "expected { length: undefined } to not have a property 'length'");
   });
 
   it('should test own.property(name)', function () {


### PR DESCRIPTION
More consistent with previous behavior, since before
expect({ a: undefined }).to.have.own.property('a') passed but
expect({ a: undefined }).to.have.property('a') failed

Also less surprising in general since before
expect( 'a' in { a: undefined } ).to.be.ok() passed but
expect({ a: undefined }).to.have.property('a') failed
