### PR TITLE
Fix bug `indexOf`. when arr is number, it was return 0

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -449,6 +449,10 @@
       return Array.prototype.indexOf.call(arr, o, i);
     }
 
+    if (arr.length === undefined) {
+      return -1;
+    }
+
     for (var j = arr.length, i = i < 0 ? i + j < 0 ? 0 : i + j : i || 0
         ; i < j && arr[i] !== o; i++);
 


### PR DESCRIPTION
Not supported `Array#indexOf` browser(under IE8), this test is failed.

```
err(function () {
  expect(3).to.contain('baz');
}, "expected 3 to contain 'baz'");
// => Error: expected 'expected 3 to contain \'baz\'' to equal 'Expected an error'
```

This is `indexOf` bug.

```
indexOf(0, 'baz'); //=> 0
```

It fixed.
