### PR TITLE
Fix for Chrome bug trying to access `selectionStart` on certain `<input>` elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea

--- a/expect.js
+++ b/expect.js
@@ -631,7 +631,13 @@
           name = '[' + key + ']';
         }
         if (!str) {
-          if (indexOf(seen, value[key]) < 0) {
+          if (value && value.nodeType &&
+            indexOf(['selectionStart', 'selectionEnd', 'selectionDirection'], key) >= 0) {
+            //chrome blows up here if value is an input that doesn't support
+            //one of these three properties (e.g. <input type="file"/>)
+            str = format('');
+          }
+          else if (indexOf(seen, value[key]) < 0) {
             if (recurseTimes === null) {
               str = format(value[key]);
             } else {

--- a/test/expect.js
+++ b/test/expect.js
@@ -527,4 +527,10 @@ describe('expect', function () {
     }, "expected 5 to be below 4");
   });
 
+  it('should not blow up when trying to access `selection*` on input elements', function() {
+    var input = document.createElement('input');
+    input.setAttribute('type', 'file');
+    expect(input).to.have.property('type', 'file');
+  });
+
 });


### PR DESCRIPTION
Chrome would explode with the following error while trying to inspect hidden and file inputs:

```
TypeError: Accessing selectionStart on an input element that cannot have a selection.
    at http://localhost:3030/expect.js:639:34
    at Array.map (native)
    at map (http://localhost:3030/expect.js:744:34)
    at format (http://localhost:3030/expect.js:615:20)
    at i (http://localhost:3030/expect.js:702:12)
    at Assertion.property (http://localhost:3030/expect.js:365:25)
    at Context.<anonymous> (http://localhost:3030/test/expect.js:533:27)
    at Test.run (http://localhost:3030/support/mocha.js:3001:32)
    at Runner.runTest (http://localhost:3030/support/mocha.js:3305:10)
    at http://localhost:3030/support/mocha.js:3349:12
```

The `selectionEnd` and `selectionDirection` properties had the same effect.
