### PR TITLE
Expose object stringification function `i`

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -1,4 +1,3 @@
-
 (function (global, module) {
 
   if ('undefined' == typeof module) {
@@ -696,6 +695,8 @@
     }
     return format(obj, (typeof depth === 'undefined' ? 2 : depth));
   };
+  
+  expect.stringify = i;
 
   function isArray (ar) {
     return Object.prototype.toString.call(ar) == '[object Array]';


### PR DESCRIPTION
This will be useful for people extending expect.js with their own assertions, so they can match expect.js style reporting.
