### PR TITLE
Fix isRegExp bug in some edge cases

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -65,7 +65,7 @@
 
         var name = $flags[i]
           , assertion = new Assertion(this.obj, name, this)
-  
+
         if ('function' == typeof Assertion.prototype[name]) {
           // clone the function, make sure we dont touch the prot reference
           var old = this[name];
@@ -148,7 +148,7 @@
     if ('object' == typeof fn && not) {
       // in the presence of a matcher, ensure the `not` only applies to
       // the matching.
-      this.flags.not = false; 
+      this.flags.not = false;
     }
 
     var name = this.obj.name || 'fn';
@@ -219,7 +219,7 @@
   };
 
   /**
-   * Assert within start to finish (inclusive). 
+   * Assert within start to finish (inclusive).
    *
    * @param {Number} start
    * @param {Number} finish
@@ -298,7 +298,7 @@
       , function(){ return 'expected ' + i(this.obj) + ' to be above ' + n });
     return this;
   };
-  
+
   /**
    * Assert string value matches _regexp_.
    *
@@ -359,13 +359,13 @@
       } catch (e) {
         hasProp = undefined !== this.obj[name]
       }
-      
+
       this.assert(
           hasProp
         , function(){ return 'expected ' + i(this.obj) + ' to have a property ' + i(name) }
         , function(){ return 'expected ' + i(this.obj) + ' to not have a property ' + i(name) });
     }
-    
+
     if (undefined !== val) {
       this.assert(
           val === this.obj[name]
@@ -537,7 +537,7 @@
       return html;
     }
   };
-  
+
   // Returns true if object is a DOM element.
   var isDOMElement = function (object) {
     if (typeof HTMLElement === 'object') {
@@ -747,7 +747,13 @@
   };
 
   function isRegExp(re) {
-    var s = '' + re;
+    var s;
+    try {
+      s = '' + re;
+    } catch (e) {
+      return false;
+    }
+
     return re instanceof RegExp || // easy case
            // duck-type for context-switching evalcx case
            typeof(re) === 'function' &&
@@ -843,9 +849,9 @@
 
   expect.eql = function eql (actual, expected) {
     // 7.1. All identical values are equivalent, as determined by ===.
-    if (actual === expected) { 
+    if (actual === expected) {
       return true;
-    } else if ('undefined' != typeof Buffer 
+    } else if ('undefined' != typeof Buffer
         && Buffer.isBuffer(actual) && Buffer.isBuffer(expected)) {
       if (actual.length != expected.length) return false;
 


### PR DESCRIPTION
``` js
var s = '' + re; // This fails for the object types mentioned bellow

[object XMLHttpRequestExceptionPrototype]
[object DOMExceptionPrototype]
[object DOMTokenListPrototype]
[object RangePrototype]
[object HTMLAnchorElementPrototype]
[object RangeExceptionPrototype]
[object XPathExceptionPrototype]
[object EventExceptionPrototype]
[object WebKitCSSMatrixPrototype]
[object SVGExceptionPrototype]
[object XMLHttpRequestExceptionPrototype]
[object DOMExceptionPrototype]
[object DOMTokenListPrototype]
[object RangePrototype]
[object HTMLAnchorElementPrototype]
[object RangeExceptionPrototype]
[object XPathExceptionPrototype]
[object EventExceptionPrototype]
[object WebKitCSSMatrixPrototype]
[object SVGExceptionPrototype]
```
