### PR TITLE
fix "sort of comparison" for dom nodes

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -890,6 +890,17 @@
     return Object.prototype.toString.call(object) == '[object Arguments]';
   }
 
+  // Returns true if it is a DOM node
+  // http://stackoverflow.com/questions/384286/javascript-isdom-how-do-you-check-if-a-javascript-object-is-a-dom-object
+  function isNode (object) {
+    return (
+      typeof Node === 'object' ? object instanceof Node :
+        object && typeof object === 'object' &&
+          typeof object.nodeType === 'number' &&
+          typeof object.nodeName === 'string'
+      );
+  }
+
   function objEquiv (a, b) {
     if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
       return false;
@@ -904,6 +915,19 @@
       a = pSlice.call(a);
       b = pSlice.call(b);
       return expect.eql(a, b);
+    }
+    if (isNode(a)) {
+      if (!isNode(b)) {
+        return false;
+      }
+      // be strict: don't ensure hasOwnProperty because
+      // nodes don't own their properties
+      for (var prop in a) {
+        if (b[prop] !== a[prop]) {
+          return false;
+        }
+      }
+      return true;
     }
     try{
       var ka = keys(a),

--- a/test/expect.js
+++ b/test/expect.js
@@ -23,6 +23,12 @@ var nameSupported;
 })();
 
 /**
+ * Detection of browser environment.
+ */
+
+var isBrowser = document && 'createElement' in document;
+
+/**
  * Tests.
  */
 
@@ -292,7 +298,16 @@ describe('expect', function () {
     err(function () {
       expect(4).to.eql(3);
     }, 'expected 4 to sort of equal 3');
+
   });
+
+  if (isBrowser) {
+    it('should test eql for dom nodes if in a browser', function () {
+      var textNode = document.createTextNode('a');
+      var unknownNode = document.createElement('c');
+      expect(textNode).to.not.eql(unknownNode);
+    });
+  }
 
   it('should test equal(val)', function () {
     expect('test').to.equal('test');
@@ -359,7 +374,7 @@ describe('expect', function () {
     err(function () {
       expect('asd').to.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
-    
+
     err(function () {
       expect({ length: undefined }).to.not.have.property('length');
     }, "expected { length: undefined } to not have a property 'length'");
@@ -380,7 +395,7 @@ describe('expect', function () {
     err(function () {
       expect('asd').to.not.have.property('foo', 3);
     }, "'asd' has no property 'foo'");
-    
+
     err(function () {
       expect({ length: undefined }).to.not.have.property('length', undefined);
     }, "expected { length: undefined } to not have a property 'length'");


### PR DESCRIPTION
`expect.eql` failed to perform "sort of comparison" for DOM nodes, always returning true for nodes even if they were of different types (say, text node and div). I stumbled upon this recently when saw this test passing:

``` javascript
var div = document.createElement('div');
var a = document.createTextNode('a');
var b = document.createTextNode('b');
div.innerHTML = '<c></c><d></d>';
var c = div.firstChild;
var d = div.lastChild;
expect([a, b]).to.be.eql([c, d]);
```

After digging through `expect.js` code with breakpoints and `console.log`s I understood that basically the [CommonJS Unit Testing 1.0 spec](http://wiki.commonjs.org/wiki/Unit_Testing/1.0) implemented by `expect.js` has no special algo for comparing nodes. So they are treated as mere objects and as such are considered "sort of equal" because their prototypes are undefined and their keys are empty (in fact, sometimes Firefox returns "constructor" as as a result of keys check, in this case this works better, but this unreliable and insufficient and also quite strange).

What I've implemented is deep `for-in` check for nodes (this in fact is what QUnit does and why comparing nodes with `deepEqual` works well there).

P. S. Sorry for multiple commits, I'm a github noob. If this needs to be cleaned up, I can create another pull request.
