### PR TITLE
Add support for 'regexp' type and eql comparison of regular expressions.

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -250,9 +250,10 @@
       // typeof with support for 'array'
       this.assert(
           'array' == type ? isArray(this.obj) :
-            'object' == type
-              ? 'object' == typeof this.obj && null !== this.obj
-              : type == typeof this.obj
+            'regexp' == type ? isRegExp(this.obj) :
+              'object' == type
+                ? 'object' == typeof this.obj && null !== this.obj
+                : type == typeof this.obj
         , function(){ return 'expected ' + i(this.obj) + ' to be a' + n + ' ' + type }
         , function(){ return 'expected ' + i(this.obj) + ' not to be a' + n + ' ' + type });
     } else {
@@ -871,6 +872,10 @@
     } else if (typeof actual != 'object' && typeof expected != 'object') {
       return actual == expected;
 
+    // If both are regular expression use the special `regExpEquiv` method
+    // to determine equivalence.
+    } else if (isRegExp(actual) && isRegExp(expected)) {
+      return regExpEquiv(actual, expected);
     // 7.4. For all other Object pairs, including Array objects, equivalence is
     // determined by having the same number of owned properties (as verified
     // with Object.prototype.hasOwnProperty.call), the same set of keys
@@ -888,6 +893,11 @@
 
   function isArguments (object) {
     return Object.prototype.toString.call(object) == '[object Arguments]';
+  }
+
+  function regExpEquiv (a, b) {
+    return a.source === b.source && a.global === b.global &&
+           a.ignoreCase === b.ignoreCase && a.multiline === b.multiline;
   }
 
   function objEquiv (a, b) {

--- a/test/expect.js
+++ b/test/expect.js
@@ -185,6 +185,15 @@ describe('expect', function () {
     }, 'expected {} to be an array');
   });
 
+  it('should test regex', function () {
+    expect(/a/).to.be.an('regexp');
+    expect(/a/).to.be.a('regexp');
+
+    err(function () {
+      expect(null).to.be.a('regexp');
+    }, 'expected null to be a regexp');
+  });
+
   it('should test objects', function () {
     expect({}).to.be.an('object');
 
@@ -288,6 +297,7 @@ describe('expect', function () {
     expect({ foo: 'bar' }).to.eql({ foo: 'bar' });
     expect(1).to.eql(1);
     expect('4').to.eql(4);
+    expect(/a/gmi).to.eql(/a/mig);
 
     err(function () {
       expect(4).to.eql(3);


### PR DESCRIPTION
This pull request adds support for a `regexp` type and equivalence comparisons of regular expressions using `eql`. I'm working on a library that generates regular expressions and I'm using expect.js to do my testing, so having native support for regular expressions would be great. Let me know if you want anything changed in the implementation or if you think it does not belong in core.

I've also updated the tests to account for the new functionality.
