### PR TITLE
Addition of formatting for Error objects.

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -1,4 +1,3 @@
-
 (function (global, module) {
 
   if ('undefined' == typeof module) {
@@ -618,6 +617,11 @@
       // Dates without properties can be shortcutted
       if (isDate(value) && $keys.length === 0) {
         return stylize(value.toUTCString(), 'date');
+      }
+      
+      // Error objects can be shortcutted
+      if (value instanceof Error) {
+        return stylize("["+value.toString()+"]", 'Error');
       }
 
       var base, type, braces;


### PR DESCRIPTION
Printing an error object from node.js generates an unhelpful `{}` response.

```
var e = new Error("Something went bad");
expect(e).to.be(null); // Prints Error: expected {} to equal null
```

Passing the response through toString gives a nicer result:

```
Prints Error: expected [Error: Something went wrong] to equal null
```
