### PR TITLE
Add .with() syntax for easier scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ expect(fn).to.throwException(/matches the exception message/);
 expect(fn2).to.not.throwException();
 ```
 
+**withArgs**: creates anonymous function to call fn with arguments
+
+```js
+expect(fn).withArgs(invalid, arg).to.throwException();
+expect(fn).withArgs(valid, arg).to.not.throwException();
+```
+
 **within**: asserts a number within a range
 
 ```js

--- a/expect.js
+++ b/expect.js
@@ -119,6 +119,19 @@
   };
 
   /**
+   * Creates an anonymous function which calls fn with arguments.
+   *
+   * @api public
+   */
+
+  Assertion.prototype.withArgs = function() {
+    expect(this.obj).to.be.a('function');
+    var fn = this.obj;
+    var args = Array.prototype.slice.call(arguments);
+    return expect(function() { fn.apply(null, args); });
+  }
+
+  /**
    * Assert that the function throws.
    *
    * @param {Function|RegExp} callback, or regexp to match error string against

--- a/test/expect.js
+++ b/test/expect.js
@@ -79,6 +79,19 @@ describe('expect', function () {
     }, "expected '' to equal false")
   });
 
+  it('should test functions with arguments', function () {
+    function itThrowsSometimes (first, second) {
+      if (first ^ second) {
+        throw new Error('tell');
+      }
+    }
+
+    expect(itThrowsSometimes).withArgs(false, false).to.not.throwException();
+    expect(itThrowsSometimes).withArgs(false, true).to.throwException(/tell/);
+    expect(itThrowsSometimes).withArgs(true, false).to.throwException(/tell/);
+    expect(itThrowsSometimes).withArgs(true, true).to.not.throwException();
+  });
+
   it('should test for exceptions', function () {
     function itThrows () {
       a.b.c;


### PR DESCRIPTION
Makes it easy to test that a function validates its inputs.
