### PR TITLE
eql(): fix wrong order of actual vs. expected

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -1,4 +1,3 @@
-
 (function (global, module) {
 
   if ('undefined' == typeof module) {
@@ -212,7 +211,7 @@
 
   Assertion.prototype.eql = function (obj) {
     this.assert(
-        expect.eql(obj, this.obj)
+        expect.eql(this.obj, obj)
       , function(){ return 'expected ' + i(this.obj) + ' to sort of equal ' + i(obj) }
       , function(){ return 'expected ' + i(this.obj) + ' to sort of not equal ' + i(obj) });
     return this;


### PR DESCRIPTION
The helper `expect.eql()` function, like typical assertion methods,
takes `actual` then `expected`:

https://github.com/LearnBoost/expect.js/blob/master/expect.js#L850

But the `Assertion.prototype.eql` wrapper has been incorrectly
passing `this.obj` (the object being tested) as the `expected`, and
vice versa passing `obj` (the object used for comparison) as the
`actual`. This fixes that.
