### PR TITLE
Alias throwException as throw

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -138,6 +138,7 @@
    * @api public
    */
 
+  Assertion.prototype['throw'] =
   Assertion.prototype.throwError =
   Assertion.prototype.throwException = function (fn) {
     expect(this.obj).to.be.a('function');


### PR DESCRIPTION
Alias `expect().throwException` as `expect().throw`.