### PR TITLE
Add means for checking that expected objects are contained in the actual array (order doesn't matter)

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -421,6 +421,46 @@
   };
 
   /**
+   * Assert that the actual array contains all expected items.
+   * Order of items doesn't matter.
+   *
+   * @param {Array} expectedItems
+   * @api public
+   */
+
+  Assertion.prototype.containAll = function (expectedItems) {
+    expect(expectedItems).to.be.an('array');
+    for (var i = 0; i < expectedItems.length; i++) {
+      expect(this.obj).to.containEql(expectedItems[i]);
+    }
+    return this;
+  };
+
+  /**
+   * Assert that the actual array contains the given obj.
+   *
+   * @param {Mixed} obj|string|int
+   * @api public
+   */
+
+  Assertion.prototype.containEql = function (obj) {
+    expect(this.obj).to.be.an('array');
+    var numFails = 0;
+    for (var index = 0; index < this.obj.length; index++) {
+      try {
+        expect(this.obj[index]).to.eql(obj);
+      } catch (e) {
+        numFails++;
+      }
+    }
+    this.assert(
+        numFails < this.obj.length
+      , function(){ return 'expected ' + i(this.obj) + ' to contain ' + i(obj) }
+      , function(){ return 'expected ' + i(this.obj) + ' to not contain ' + i(obj) });
+    return this;
+  };
+
+  /**
    * Assert exact keys or inclusion of keys by using
    * the `.own` modifier.
    *

--- a/test/expect.js
+++ b/test/expect.js
@@ -455,6 +455,29 @@ describe('expect', function () {
     }, "expected [ 'bar', 'foo' ] to not contain 'foo'");
   });
 
+  it('should test containAll()', function () {
+    expect([{a: 1}, {b: 2}, {c: 3}]).to.containAll([{c: 3}, {a: 1}]);
+    expect([true, 123, 'foo', {a: 1}]).to.containAll(['foo', {a: 1}, 123], true);
+    err(function () {
+      expect([]).to.containAll(1);
+    }, "expected 1 to be an array");
+    err(function () {
+      expect([{a: 1}, {b: 2}]).to.containAll([{b: 2}, {c: 3}]);
+    }, "expected [ { a: 1 }, { b: 2 } ] to contain { c: 3 }");
+  });
+
+  it('should test containEql()', function () {
+    expect([{a: 1}, {b: 2}, {c: 3}]).to.containEql({b: 2});
+    expect([1, 2]).to.containEql(1);
+    expect(['a', 'b']).to.containEql('b');
+    err(function () {
+      expect({a: 1}).to.containEql(1);
+    }, "expected { a: 1 } to be an array");
+    err(function () {
+      expect([{a: 1}, {b: 2}]).to.containEql({c: 3});
+    }, "expected [ { a: 1 }, { b: 2 } ] to contain { c: 3 }");
+  });
+
   it('should test keys(array)', function () {
     expect({ foo: 1 }).to.have.keys(['foo']);
     expect({ foo: 1, bar: 2 }).to.have.keys(['foo', 'bar']);


### PR DESCRIPTION
Quite often it's necessary to check that some items (objects/strings/arrays etc.) are found in the actual array. With this patch things become really easy. Previously there was only `contain` which doesn't support deep equality check for objects. Now there's `containAll` for checking multiple items at the same time and `containEql` for checking only one item.

When using `containAll` the order of the items doesn't matter. This is great especially when the test can't affect the order that production code provides.

Example from our app spec where the order of items are shuffled by production code:

``` coffeescript
winnings = _.map $('#winning-news li'), (li) ->
  [$(li).find('.location').text(), $(li).find('.amount').text()]
expect(winnings).to.have.length(3).and.to.containAll([
  ['Espoo', '10 €']
  ['Helsinki', '323 €']
  ['Tampere', '59,20 €']
])
```
