### PR TITLE
Add approximate and approximately

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -253,6 +253,23 @@
   };
 
   /**
+   * Assert within value +- delta (inclusive).
+   *
+   * @param {Number} value
+   * @param {Number} delta
+   * @api public
+   */
+
+  Assertion.prototype.approximate =
+  Assertion.prototype.approximately = function (value, delta) {
+    this.assert(
+        Math.abs(this.obj - value) <= delta
+      , function(){ return 'expected ' + i(this.obj) + ' to be approximately ' + value + ' +- ' + delta }
+      , function(){ return 'expected ' + i(this.obj) + ' to not be approximately ' + value + " +- " + delta });
+    return this;
+  };
+
+  /**
    * Assert typeof / instance of
    *
    * @api public

--- a/test/expect.js
+++ b/test/expect.js
@@ -263,6 +263,20 @@ describe('expect', function () {
     }, "expected 10 to be within 50..100");
   });
 
+  it('should test approximately(value, delta)', function() {
+    expect(1.5).to.approximate(1.4, 0.2);
+    expect(1.5).to.approximate(1.5, 10E-10);
+    expect(1.5).to.not.approximate(1.4, 1E-2);
+
+    err(function () {
+      expect(99.99).to.not.approximate(100, 0.1);
+    }, "expected 99.99 to not be approximately 100 +- 0.1");
+
+    err(function () {
+      expect(99.99).to.approximate(105, 0.1);
+    }, "expected 99.99 to be approximately 105 +- 0.1");
+  });
+
   it('should test above(n)', function () {
     expect(5).to.be.above(2);
     expect(5).to.be.greaterThan(2);


### PR DESCRIPTION
Approximates the `to.approximate` and `to.be.approximately` syntax from `should.js`.

``` js
expect(0.99999).to.approximate(0.99998, 4); // works
expect(0.99999).to.approximate(0.99998, 5); // fails
expect(0.999999).to.approximate(0.999998, 5); // works
expect(0.999999).to.approximate(0.999998, 6); // fails

expect(0.99999).to.be.approximately(0.99998, 4); // works
expect(0.99999).to.be.approximately(0.99998, 5); // fails
expect(0.999999).to.be.approximately(0.999998, 5); // works
expect(0.999999).to.be.approximately(0.999998, 6); // fails
```

This closes #83.
