### PR TITLE
Add startsWith and endsWith

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -318,6 +318,42 @@
   };
 
   /**
+   * Assert string or buffer starts with _value_.
+   *
+   * @param {String|Buffer} value
+   * @api public
+   */
+
+  Assertion.prototype.startWith = function (value) {
+    expect(this.obj).to.be.ok();
+    expect(this.obj.slice).to.be.a('function');
+    this.assert(
+        expect.eql(this.obj.slice(0, value.length), value)
+      , function(){ return 'expected ' + i(this.obj) + ' to start with ' + i(value) }
+      , function(){ return 'expected ' + i(this.obj) + ' to not start with ' + i(value) });
+    return this;
+  };
+
+  /**
+   * Assert string or buffer ends with _value_.
+   *
+   * @param {String|Buffer} value
+   * @api public
+   */
+
+  Assertion.prototype.endWith = function (value) {
+    expect(this.obj).to.be.ok();
+    expect(this.obj.slice).to.be.a('function');
+    this.assert(
+        value.length == 0
+        ? expect.eql(this.obj.slice(0, 0), value)
+        : expect.eql(this.obj.slice(-value.length), value)
+      , function(){ return 'expected ' + i(this.obj) + ' to end with ' + i(value) }
+      , function(){ return 'expected ' + i(this.obj) + ' to not end with ' + i(value) });
+    return this;
+  };
+
+  /**
    * Assert string value matches _regexp_.
    *
    * @param {RegExp} regexp

--- a/test/expect.js
+++ b/test/expect.js
@@ -278,6 +278,50 @@ describe('expect', function () {
     }, "expected 10 to be below 6");
   });
 
+  it('should test startWith(value)', function () {
+    expect('hello').to.startWith('hello');
+    expect('hello').to.startWith('he');
+    expect('hello').to.startWith('');
+    expect('hello').to.not.startWith('H');
+    expect('goodbye').to.not.startWith('hello');
+
+    expect(new Buffer('hello')).to.startWith(new Buffer('hello'));
+    expect(new Buffer('hello')).to.startWith(new Buffer('he'));
+    expect(new Buffer('hello')).to.startWith(new Buffer(''));
+    expect(new Buffer('hello')).to.not.startWith(new Buffer('H'));
+    expect(new Buffer('goodbye')).to.not.startWith(new Buffer('hello'));
+
+    err(function () {
+      expect('hello').to.startWith('goodbye');
+    }, "expected 'hello' to start with 'goodbye'");
+
+    err(function () {
+      expect('goodbye').to.not.startWith('good');
+    }, "expected 'goodbye' to not start with 'good'");
+  });
+
+  it('should test endWith(value)', function () {
+    expect('hello').to.endWith('hello');
+    expect('hello').to.endWith('lo');
+    expect('hello').to.endWith('');
+    expect('hello').to.not.endWith('O');
+    expect('goodbye').to.not.endWith('hello');
+
+    expect(new Buffer('hello')).to.endWith(new Buffer('hello'));
+    expect(new Buffer('hello')).to.endWith(new Buffer('lo'));
+    expect(new Buffer('hello')).to.endWith(new Buffer(''));
+    expect(new Buffer('hello')).to.not.endWith(new Buffer('O'));
+    expect(new Buffer('goodbye')).to.not.endWith(new Buffer('hello'));
+
+    err(function () {
+      expect('hello').to.endWith('goodbye');
+    }, "expected 'hello' to end with 'goodbye'");
+
+    err(function () {
+      expect('goodbye').to.not.endWith('bye');
+    }, "expected 'goodbye' to not end with 'bye'");
+  });
+
   it('should test match(regexp)', function () {
     expect('foobar').to.match(/^foo/)
     expect('foobar').to.not.match(/^bar/)


### PR DESCRIPTION
Adds shortcuts to check if a string/buffer (any object with a slice method and a length) starts with or ends with a given value.

``` js
expect('hello').to.startWith('hello');
expect('hello').to.startWith('he');
expect('hello').to.startWith('');
expect('hello').to.not.startWith('H');
expect('goodbye').to.not.startWith('hello');

expect(new Buffer('hello')).to.endWith(new Buffer('hello'));
expect(new Buffer('hello')).to.endWith(new Buffer('lo'));
expect(new Buffer('hello')).to.endWith(new Buffer(''));
expect(new Buffer('hello')).to.not.endWith(new Buffer('O'));
expect(new Buffer('goodbye')).to.not.endWith(new Buffer('hello'));
```
