### PR TITLE
Add test for cyclic structures

### DIFF
--- a/test/expect.js
+++ b/test/expect.js
@@ -343,6 +343,18 @@ describe('expect', function () {
     }, "expected '4' to equal 4");
   });
 
+  it('should test eql(val) with cyclic structures', function () {
+    var one = {hello: 'world'}, two = {hello: 'world'};
+    one.next = one;
+    two.next = two;
+    expect(one).to.eql(two);
+
+    var three = ['hello'], four = ['hello'];
+    three.push(three);
+    four.push(four);
+    expect(obj).to.eql(obj);
+  });
+
   it('should test empty', function () {
     expect('').to.be.empty();
     expect({}).to.be.empty();


### PR DESCRIPTION
This adds a test for simple cyclic structures, but lacks an implementation of eql() which actually checks. See #50.
