### PR TITLE
Fixed: pSlice is undefined when comparing arguments for equality

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -933,6 +933,7 @@
       if (!isArguments(b)) {
         return false;
       }
+      var pSlice = Array.prototype.slice;
       a = pSlice.call(a);
       b = pSlice.call(b);
       return expect.eql(a, b);

--- a/test/expect.js
+++ b/test/expect.js
@@ -311,6 +311,8 @@ describe('expect', function () {
     expect(1).to.eql(1);
     expect('4').to.eql(4);
     expect(/a/gmi).to.eql(/a/mig);
+    function returnArguments() { return arguments; }
+    expect(returnArguments(0,1,2,3)).to.eql(returnArguments(0,1,2,3));
 
     err(function () {
       expect(4).to.eql(3);


### PR DESCRIPTION
I added a failing test to pinpoint the problem and fixed the failing
test by defining pSlice to be Array.prototype.slice.
