### PR TITLE
added about/near/approximately functionality

### DIFF
--- a/expect.js
+++ b/expect.js
@@ -221,6 +221,21 @@
   };
 
   /**
+   * Checks if the number is approximately another.
+   *
+   * @api public
+   */
+
+  Assertion.prototype.near =
+  Assertion.prototype.about = function (obj) {
+    this.assert(
+      Math.abs(obj - this.obj) < 0.005
+      , function(){ return 'expected ' + i(this.obj) + ' to be near ' + i(obj) }
+      , function(){ return 'expected ' + i(this.obj) + ' to not be near ' + i(obj) });
+    return this;
+  };
+
+  /**
    * Checks if the obj sortof equals another.
    *
    * @api public

--- a/expect.js
+++ b/expect.js
@@ -227,6 +227,8 @@
    */
 
   Assertion.prototype.near =
+  Assertion.prototype.approximately =
+  Assertion.prototype.approximate =
   Assertion.prototype.about = function (value, precision) {
     if (precision == null) precision = 2;
     var diff = Math.pow(10, -precision) / 2;

--- a/expect.js
+++ b/expect.js
@@ -227,9 +227,11 @@
    */
 
   Assertion.prototype.near =
-  Assertion.prototype.about = function (obj) {
+  Assertion.prototype.about = function (value, precision) {
+    if (precision == null) precision = 2;
+    var diff = Math.pow(10, -precision) / 2;
     this.assert(
-      Math.abs(obj - this.obj) < 0.005
+      Math.abs(obj - this.obj) < diff
       , function(){ return 'expected ' + i(this.obj) + ' to be near ' + i(obj) }
       , function(){ return 'expected ' + i(this.obj) + ' to not be near ' + i(obj) });
     return this;

--- a/expect.js
+++ b/expect.js
@@ -229,7 +229,7 @@
   Assertion.prototype.near =
   Assertion.prototype.approximately =
   Assertion.prototype.approximate =
-  Assertion.prototype.about = function (value, precision) {
+  Assertion.prototype.about = function (obj, precision) {
     if (precision == null) precision = 2;
     var diff = Math.pow(10, -precision) / 2;
     this.assert(


### PR DESCRIPTION
After switching from Jasmine to Mocha and expect.js, I ran into one minor snag while porting my old tests - there didn't appear to be any equivalent to Jasmine's .toBeCloseTo() method.  I did my best match the style used in expect.js.

Sample syntax:

``` javascript
describe( 'about sample', function () {
  it( 'should work without custom precision', function () {
    expect( Math.PI ).to.be.about( 3.14 );
    expect( Math.PI ).not.to.be.near( 3.15 );
    expect( Math.PI ).to.be.approximately( 3.145 );
  } );

  it( 'should work with custom precision', function () {
    expect( Math.PI ).to.be.about( 3.1416, 4 );
    expect( Math.PI ).not.to.be.near( 3.14, 5 );
    expect( Math.PI ).not.to.be.approximately( 3.1415, 4 );
    expect( Math.PI ).to.be.approximate( 3.1, 1 );
  } );
} );
```
