### PR TITLE
added repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   , "version": "0.2.0"
   , "description": "BDD style assertions for node and the browser."
   , "main": "./expect"
+  , "repository": {
+        "type": "git",
+        "url": "git://github.com/LearnBoost/expect.js.git"
+    }
   , "devDependencies": {
         "mocha": "*"
       , "serve": "*"


### PR DESCRIPTION
this will stop npm from throwing a warning everytime expect.js is installed

```
npm WARN package.json expect.js@0.2.0 No repository field.
```
