### PR TITLE
Enforce `arguments` constraint reflexively

### DIFF
--- a/index.js
+++ b/index.js
@@ -929,10 +929,11 @@
     if (a.prototype !== b.prototype) return false;
     //~~~I've managed to break Object.keys through screwy arguments passing.
     //   Converting to array solves the problem.
-    if (isArguments(a)) {
-      if (!isArguments(b)) {
-        return false;
-      }
+    var aIsArgs = isArguments(a),
+        bIsArgs = isArguments(b);
+    if ((aIsArgs && !bIsArgs) || (!aIsArgs && bIsArgs))
+      return false;
+    if (aIsArgs) {
       a = pSlice.call(a);
       b = pSlice.call(b);
       return expect.eql(a, b);

--- a/test/expect.js
+++ b/test/expect.js
@@ -312,6 +312,14 @@ describe('expect', function () {
     expect('4').to.eql(4);
     expect(/a/gmi).to.eql(/a/mig);
 
+    err(function() {
+      expect([]).to.eql(arguments);
+    }, 'expected [] to sort of equal {}');
+
+    err(function() {
+      expect(arguments).to.eql([]);
+    }, 'expected {} to sort of equal []');
+
     err(function () {
       expect(4).to.eql(3);
     }, 'expected 4 to sort of equal 3');


### PR DESCRIPTION
My personal preference would be for `eql` to be _more_ lax (as opposed to less)--considering `arguments` objects as equivalent to arrays if their elements are deeply equal. Since this project uses Node.js's `deepEqual` logic, I assume this is not the intention of `eql`. The important thing is consistency, as a patch like 7c2052351263ddeb7afe2018dbd9d040ad8bf2e9 should not have [effected downstream libraries](https://github.com/MatthewMueller/cheerio/pull/350).

Commit message:

> If an `arguments` object is not considered `eql` to an array, then the
> inverse should also hold true.
