### PR TITLE
Added new test methods lessThanOrEqual() and greaterThanOrEqual()

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
 
+0.3.3 / 2014-??-??
+==================
+
+ * added .lessThanOrEqual() and .greaterThanOrEqual()
+
+
 0.3.0 / 2014-02-20
 ==================
 

--- a/index.js
+++ b/index.js
@@ -302,6 +302,22 @@
   };
 
   /**
+   * Assert numeric value above or equal _n_.
+   *
+   * @param {Number} n
+   * @api public
+   */
+
+  Assertion.prototype.greaterThanOrEqual =
+  Assertion.prototype.aboveOrEqual = function (n) {
+    this.assert(
+        this.obj >= n
+      , function(){ return 'expected ' + i(this.obj) + ' to be above or equal ' + n }
+      , function(){ return 'expected ' + i(this.obj) + ' to be below ' + n });
+    return this;
+  };
+
+  /**
    * Assert numeric value below _n_.
    *
    * @param {Number} n
@@ -313,6 +329,22 @@
     this.assert(
         this.obj < n
       , function(){ return 'expected ' + i(this.obj) + ' to be below ' + n }
+      , function(){ return 'expected ' + i(this.obj) + ' to be above ' + n });
+    return this;
+  };
+
+  /**
+   * Assert numeric value below or equal _n_.
+   *
+   * @param {Number} n
+   * @api public
+   */
+
+  Assertion.prototype.lessThanOrEqual =
+  Assertion.prototype.belowOrEqual = function (n) {
+    this.assert(
+        this.obj <= n
+      , function(){ return 'expected ' + i(this.obj) + ' to be below or equal ' + n }
       , function(){ return 'expected ' + i(this.obj) + ' to be above ' + n });
     return this;
   };

--- a/test/common.js
+++ b/test/common.js
@@ -4,4 +4,4 @@
  */
 
 // expose the globals that are obtained through `<script>` on the browser
-expect = require('../expect')
+expect = require('../index');

--- a/test/expect.js
+++ b/test/expect.js
@@ -278,9 +278,43 @@ describe('expect', function () {
     }, "expected 10 to be below 6");
   });
 
+  it('should test aboveOrEqual(n)', function () {
+    expect(5).to.be.aboveOrEqual(2);
+    expect(5).to.be.aboveOrEqual(5);
+    expect(5).to.be.greaterThanOrEqual(2);
+    expect(5).to.be.greaterThanOrEqual(5);
+    expect(5).to.not.be.aboveOrEqual(6);
+    expect(5).to.not.be.greaterThanOrEqual(6);
+
+    err(function () {
+      expect(5).to.be.aboveOrEqual(6);
+    }, "expected 5 to be above or equal 6");
+
+    err(function () {
+      expect(10).to.not.be.aboveOrEqual(6);
+    }, "expected 10 to be below 6");
+  });
+
+  it('should test belowOrEqual(n)', function () {
+    expect(5).to.be.belowOrEqual(9);
+    expect(5).to.be.belowOrEqual(5);
+    expect(5).to.be.lessThanOrEqual(9);
+    expect(5).to.be.lessThanOrEqual(5);
+    expect(5).to.not.be.belowOrEqual(3);
+    expect(5).to.not.be.lessThanOrEqual(3);
+
+    err(function () {
+      expect(5).to.be.belowOrEqual(3);
+    }, "expected 5 to be below or equal 3");
+
+    err(function () {
+      expect(10).to.not.be.belowOrEqual(30);
+    }, "expected 10 to be above 30");
+  });
+
   it('should test match(regexp)', function () {
-    expect('foobar').to.match(/^foo/)
-    expect('foobar').to.not.match(/^bar/)
+    expect('foobar').to.match(/^foo/);
+    expect('foobar').to.not.match(/^bar/);
 
     err(function () {
       expect('foobar').to.match(/^bar/i)


### PR DESCRIPTION
Hi,

while writing tests for a graph layout algorithm, I've needed to more test methods, like

```
expect(3).to.be.belowOrEqual(9);
expect(5).to.be.aboveOrEqual(2);
```

So I've added them to expect.js library.
Tests are included.

Regards
Martin
