### PR TITLE
ThrowException can accept string to match exception message

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ expect(fn).to.throwException(function (e) { // get the exception object
   expect(e).to.be.a(SyntaxError);
 });
 expect(fn).to.throwException(/matches the exception message/);
+expect(fn).to.throwException('exactly matches the exception message');
 expect(fn2).to.not.throwException();
 ```
 

--- a/index.js
+++ b/index.js
@@ -156,13 +156,20 @@
         } else {
           expect(subject).to.match(fn);
         }
+      } else if ('string' == typeof fn) {
+        var subject = 'string' == typeof e ? e : e.message;
+        if (not) {
+          expect(subject).not.to.equal(fn);
+        } else {
+          expect(subject).to.equal(fn);
+        }
       } else if ('function' == typeof fn) {
         fn(e);
       }
       thrown = true;
     }
 
-    if (isRegExp(fn) && not) {
+    if ((isRegExp(fn) && not) || ('string' == typeof fn && not)) {
       // in the presence of a matcher, ensure the `not` only applies to
       // the matching.
       this.flags.not = false;

--- a/test/expect.js
+++ b/test/expect.js
@@ -133,6 +133,13 @@ describe('expect', function () {
       expect(itThrowsMessage).to.throwException(/no match/);
     }, 'expected \'tobi\' to match /no match/');
 
+    expect(itThrowsMessage).to.throwException('tobi');
+    expect(itThrowsMessage).to.not.throwException('test');
+
+    err(function () {
+      expect(itThrowsMessage).to.throwException('no match');
+    }, 'expected \'tobi\' to equal \'no match\'');
+
     var subject2;
 
     expect(itThrowsString).to.throwException(function (str) {


### PR DESCRIPTION
Hi,
I have prepared this pull request for the feature request asked in https://github.com/LearnBoost/expect.js/issues/115.

I hope you will like it.
