### PR TITLE
Added alias throw to throwException/throwError

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ expect({ a: 'b', c: 'd' }).to.only.have.keys(['a', 'c']);
 expect({ a: 'b', c: 'd' }).to.not.only.have.key('a');
 ```
 
-**throwException**/**throwError**: asserts that the `Function` throws or not when called
+**throw**/**throwException**/**throwError**: asserts that the `Function` throws or not when called
 
 ```js
+expect(fn).to.throw(); // synonym of throwException
 expect(fn).to.throwError(); // synonym of throwException
 expect(fn).to.throwException(function (e) { // get the exception object
   expect(e).to.be.a(SyntaxError);
@@ -207,7 +208,7 @@ and shown/processed by the test runner.
 
 ## Differences with should.js
 
-- No need for static `should` methods like `should.strictEqual`. For example, 
+- No need for static `should` methods like `should.strictEqual`. For example,
   `expect(obj).to.be(undefined)` works well.
 - Some API simplifications / changes.
 - API changes related to browser compatibility.

--- a/index.js
+++ b/index.js
@@ -138,6 +138,7 @@
    * @api public
    */
 
+  Assertion.prototype['throw'] =
   Assertion.prototype.throwError =
   Assertion.prototype.throwException = function (fn) {
     expect(this.obj).to.be.a('function');
@@ -637,7 +638,7 @@
       if (isDate(value) && $keys.length === 0) {
         return stylize(value.toUTCString(), 'date');
       }
-      
+
       // Error objects can be shortcutted
       if (value instanceof Error) {
         return stylize("["+value.toString()+"]", 'Error');

--- a/test/expect.js
+++ b/test/expect.js
@@ -156,6 +156,14 @@ describe('expect', function () {
 
     expect(called).to.be(false);
 
+    var called2 = false;
+
+    expect(itWorks).to.not.throw(function () {
+      called2 = true;
+    });
+
+    expect(called2).to.be(false);
+
     err(function () {
       expect(5).to.throwException();
     }, 'expected 5 to be a function');
@@ -382,7 +390,7 @@ describe('expect', function () {
     err(function () {
       expect('asd').to.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
-    
+
     err(function () {
       expect({ length: undefined }).to.not.have.property('length');
     }, "expected { length: undefined } to not have a property 'length'");
@@ -403,7 +411,7 @@ describe('expect', function () {
     err(function () {
       expect('asd').to.not.have.property('foo', 3);
     }, "'asd' has no property 'foo'");
-    
+
     err(function () {
       expect({ length: undefined }).to.not.have.property('length', undefined);
     }, "expected { length: undefined } to not have a property 'length'");


### PR DESCRIPTION
Hi.
I have added alias "throw" to throwException and throwError assertions. It is short, nice and used by other assertion frameworks (e.g. chai.js).