### PR TITLE
`.which` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ expect(window).to.have.property('expect', expect)
 expect({a: 'b'}).to.have.property('a');
 ```
 
+**which**: chains tests on your properties
+
+````js
+expect({
+  foo : []
+}).to.have.property("foo")
+  .which.is.an("array");
+````
+
 **key**/**keys**: asserts the presence of a key. Supports the `only` modifier
 
 ```js

--- a/expect.js
+++ b/expect.js
@@ -25,6 +25,7 @@
   var flags = {
       not: ['to', 'be', 'have', 'include', 'only']
     , to: ['be', 'have', 'include', 'only', 'not']
+    , has : ['own']
     , only: ['have']
     , have: ['own']
     , be: ['an']
@@ -339,6 +340,9 @@
    */
 
   Assertion.prototype.property = function (name, val) {
+    // make a new object so the tester can test the new object too
+    this.which = expect(this.obj[name]);
+
     if (this.flags.own) {
       this.assert(
           Object.prototype.hasOwnProperty.call(this.obj, name)

--- a/test/expect.js
+++ b/test/expect.js
@@ -395,6 +395,18 @@ describe('expect', function () {
     }, "expected { length: 12 } to not have own property 'length'");
   });
 
+  it("should test property().which", function () {
+    expect({ foo: {
+      bar : 0
+    }}).to.have.property("foo").which.eql({ bar : 0 });
+  });
+
+  it("should allow .has after .which", function () {
+    expect({ foo: {
+      bar : 0
+    }}).to.have.property("foo").which.has.property("bar", 0);
+  });
+
   it('should test string()', function () {
     expect('foobar').to.contain('bar');
     expect('foobar').to.contain('foo');


### PR DESCRIPTION
This is something I'll find very useful. I've tried to make the tests illustrate the benefit, but in a bit more detail:

``` js
expect(fooBar).to.have.property("foo").which.is.an("object")
  .and.has.property("bar").which.is.a("function");
```

and this is the equivalent without `.which`:

``` js
expect(fooBar).to.have.property("foo");
expect(fooBar.foo).to.be.an("object")
  .and.to.have.property("bar");
expect(fooBar.foo.bar).to.be.a("function");
```
