### PR TITLE
added support for Promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
   , "devDependencies": {
         "mocha": "*"
       , "serve": "*"
+      , "bluebird": "*"
     }
 }

--- a/test/expect.js
+++ b/test/expect.js
@@ -3,6 +3,8 @@
  * Module dependencies.
  */
 
+Promise = require("bluebird");
+
 function err (fn, msg) {
   try {
     fn();
@@ -568,6 +570,22 @@ describe('expect', function () {
     err(function () {
         expect().fail("explicit failure with message");
     }, "explicit failure with message");
+  });
+
+  it('should test a Promise that rejects with a reason', function () {
+    return expect(Promise.reject('Some reason')).to.be.rejectedWith(/Some reason/);
+  });
+
+  it('should test a Promise that resolves with some value', function () {
+    return expect(Promise.resolve({'test': 'value'})).to.be.resolvedWith({'test': 'value'});
+  });
+
+  it('should test negativity with both reject', function () {
+    return expect(Promise.reject('Some reason')).to.not.be.rejectedWith(/Some other reason/);
+  });
+
+  it('should test negativity with reject/resolve', function () {
+    return expect(Promise.reject('Some reason')).to.not.be.resolved();
   });
 
 });


### PR DESCRIPTION
Makes it easier to assert Promises with simple .resolved/.resolvedWith and rejected/rejectedWith functions. Noticed that before it was not possible to test if a promise was rejected, the test would error out.
