### PR TITLE
Fix eql for ES6 Set objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -931,6 +931,11 @@
   var BreakException = {};
 
   function setEquiv (a, b) {
+
+    if (a.size !== b.size) {
+      return false;
+    }
+
     try {
       a.forEach(function (item) {
         if (!b.has(item)) {

--- a/index.js
+++ b/index.js
@@ -899,6 +899,11 @@
     // to determine equivalence.
     } else if (isRegExp(actual) && isRegExp(expected)) {
       return regExpEquiv(actual, expected);
+    // If both are the ES6 Set class, use the special `setEquiv` method
+    // to determine equivalence
+    } else if ('undefined' !== typeof Set
+        && actual instanceof Set && expected instanceof Set) {
+      return setEquiv(actual, expected);
     // 7.4. For all other Object pairs, including Array objects, equivalence is
     // determined by having the same number of owned properties (as verified
     // with Object.prototype.hasOwnProperty.call), the same set of keys
@@ -921,6 +926,27 @@
   function regExpEquiv (a, b) {
     return a.source === b.source && a.global === b.global &&
            a.ignoreCase === b.ignoreCase && a.multiline === b.multiline;
+  }
+
+  var BreakException = {};
+
+  function setEquiv (a, b) {
+    try {
+      a.forEach(function (item) {
+        if (!b.has(item)) {
+          // short-circuit by throwing on first difference
+          throw BreakException
+        }
+      });
+    } catch (e) {
+      if (e === BreakException) {
+        return false;
+      } else {
+        // pass on any exceptions that we didn't generate
+        throw e;
+      }
+    }
+    return true;
   }
 
   function objEquiv (a, b) {

--- a/test/expect.js
+++ b/test/expect.js
@@ -544,6 +544,14 @@ describe('expect', function () {
     }, "expected { a: 'b', c: 'd' } to only have key 'a'");
   });
 
+  it('should test eql(Set)', function () {
+    expect(new Set([1, 2, 3])).to.be.eql(new Set([1, 2, 3]));
+    expect(new Set([1, 2, 3])).to.not.be.eql(new Set([1]));
+    expect(new Set([1, 2, 3])).to.not.be.eql([1, 2, 3]);
+    expect([1, 2, 3]).to.not.be.eql(new Set([1, 2, 3]));
+    expect(new Set()).to.not.be.eql(null);
+  });
+
   it('should allow chaining with `and`', function () {
     expect(5).to.be.a('number').and.be(5);
     expect(5).to.be.a('number').and.not.be(6);

--- a/test/expect.js
+++ b/test/expect.js
@@ -547,6 +547,7 @@ describe('expect', function () {
   it('should test eql(Set)', function () {
     expect(new Set([1, 2, 3])).to.be.eql(new Set([1, 2, 3]));
     expect(new Set([1, 2, 3])).to.not.be.eql(new Set([1]));
+    expect(new Set([1])).to.not.be.eql(new Set([1, 2, 3]));
     expect(new Set([1, 2, 3])).to.not.be.eql([1, 2, 3]);
     expect([1, 2, 3]).to.not.be.eql(new Set([1, 2, 3]));
     expect(new Set()).to.not.be.eql(null);


### PR DESCRIPTION
Do an instanceof test for the objects, if they are both Set classes then treat is as a special case, and use the new setEquiv function.

Added tests that previously failed, and now pass with my changes.
