### PR TITLE
Add containEql() to support deep equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ expect([1, 2]).to.contain(1);
 expect('hello world').to.contain('world');
 ```
 
+**containEql**: works like `contain`, but uses the deep equality
+
+```js
+expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.containEql({ a: 1, b: 2 });
+```
+
 **length**: asserts array `.length`
 
 ```js

--- a/index.js
+++ b/index.js
@@ -422,6 +422,36 @@
   };
 
   /**
+   * Assert that the array contains _obj_ or string contains _obj_.
+   * The difference from _contain_ is that _containEql_ uses the deep equality
+   * to compare _obj_ with array elements.
+   *
+   * @param {Mixed} obj|string
+   * @api public
+   */
+
+  Assertion.prototype.containEql = function(obj) {
+    if ('object' != typeof this.obj) {
+      return this.contain(obj);
+    }
+
+    var found = false;
+    for (var j = 0; j < this.obj.length; j++) {
+      if (expect.eql(this.obj[j], obj)) {
+        found = true;
+        break;
+      }
+    }
+
+    this.assert(
+        found
+      , function() { return 'expected ' + i(this.obj) + ' to contain ' + i(obj); }
+      , function() { return 'expected ' + i(this.obj) + ' to not contain ' + i(obj); });
+
+    return this;
+  };
+
+  /**
    * Assert exact keys or inclusion of keys by using
    * the `.own` modifier.
    *

--- a/test/expect.js
+++ b/test/expect.js
@@ -463,6 +463,24 @@ describe('expect', function () {
     }, "expected [ 'bar', 'foo' ] to not contain 'foo'");
   });
 
+  it('should test containEql()', function () {
+    expect(['foo', 'bar']).to.containEql('foo');
+    expect([1, 2]).to.containEql(1);
+    expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.containEql({ a: 1, b: 2 });
+
+    expect(['foo', 'bar']).to.not.containEql('baz');
+    expect(['foo', 'bar']).to.not.containEql(1);
+    expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.not.containEql({ a: 5, b: 6 });
+
+    err(function () {
+      expect(['foo']).to.containEql('bar');
+    }, "expected [ 'foo' ] to contain 'bar'");
+
+    err(function () {
+      expect(['bar', 'foo']).to.not.containEql('foo');
+    }, "expected [ 'bar', 'foo' ] to not contain 'foo'");
+  });
+
   it('should test keys(array)', function () {
     expect({ foo: 1 }).to.have.keys(['foo']);
     expect({ foo: 1, bar: 2 }).to.have.keys(['foo', 'bar']);


### PR DESCRIPTION
The existent `contain` doesn't support object comparison.

``` js
expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.containEql({ a: 1, b: 2 });
expect([{ a: 1, b: 2 }, { a: 3, b: 4 }]).to.not.containEql({ a: 5, b: 6 });
```
