### PR TITLE
Fix repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ and shown/processed by the test runner.
 Clone the repository and install the developer dependencies:
 
 ```
-git clone git://github.com/LearnBoost/expect.js.git expect
+git clone git://github.com/Automattic/expect.js.git expect
 cd expect && npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   }
   , "repository": {
         "type": "git",
-        "url": "git://github.com/LearnBoost/expect.js.git"
+        "url": "git://github.com/Automattic/expect.js.git"
     }
   , "devDependencies": {
         "mocha": "*"


### PR DESCRIPTION
Now expect.js is served from Automattic organization, not a LearnBoost.
