### PR TITLE
fix of Type Error on first line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Minimalistic BDD assertion toolkit based on
 [should.js](http://github.com/visionmedia/should.js)
 
 ```js
-expect(window.r).to.be(undefined);
+expect(window.r).to.equal(undefined);
 expect({ a: 'b' }).to.eql({ a: 'b' })
 expect(5).to.be.a('number');
 expect([]).to.be.an('array');


### PR DESCRIPTION
Changed expect().to.be(undefined) -> expect().to.equal(undefined)

expect().to.be is an Assertion object, not a Function
without this correction, to.be() -> invokes Type Error expect().to.be is not a Function