### PR TITLE
docs: Fix simple typo, seperated -> separated

### DIFF
--- a/support/jquery.js
+++ b/support/jquery.js
@@ -2278,7 +2278,7 @@ jQuery.fn.extend({
           classNames = value.split( rspace );
 
         while ( (className = classNames[ i++ ]) ) {
-          // check each className given, space seperated list
+          // check each className given, space separated list
           state = isBool ? state : !self.hasClass( className );
           self[ state ? "addClass" : "removeClass" ]( className );
         }


### PR DESCRIPTION
There is a small typo in support/jquery.js.

Should read `separated` rather than `seperated`.

