### PR TITLE
Adding license info to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "expect.js"
   , "version": "0.3.1"
   , "description": "BDD style assertions for node and the browser."
+  , "license": "MIT"
   , "scripts": {
     "test": "mocha --require ./test/common --growl test/expect.js"
   }


### PR DESCRIPTION
Tools like VersionEye are using this information for license compliance reasons. Would be nice if the information is in the package.json.