### PR TITLE
Fix #58: Expect to.have.length() function pass for any input with positive-length

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,13 +336,14 @@
   /**
    * Assert property "length" exists and has value of _n_.
    *
-   * @param {Number} n
+   * @param {Number|undefined} n
    * @api public
    */
 
   Assertion.prototype.length = function (n) {
     expect(this.obj).to.have.property('length');
     var len = this.obj.length;
+    n = n === undefined ? 0 : n;
     this.assert(
         n == len
       , function(){ return 'expected ' + i(this.obj) + ' to have a length of ' + n + ' but got ' + len }

--- a/test/expect.js
+++ b/test/expect.js
@@ -313,6 +313,20 @@ describe('expect', function () {
     }, "expected 'asd' to not have a length of 3");
   });
 
+  it('should test length without input', function () {
+    expect('test').to.have.length();
+    expect('test').to.not.have.length();
+    expect([1,2,3]).to.have.length();
+
+    err(function () {
+      expect(4).to.have.length();
+    }, 'expected 4 to have a property \'length\'');
+
+    err(function () {
+      expect('asd').to.not.have.length();
+    }, "expected 'asd' to not have a length of 3");
+  });
+
   it('should test eql(val)', function () {
     expect('test').to.eql('test');
     expect({ foo: 'bar' }).to.eql({ foo: 'bar' });


### PR DESCRIPTION
https://github.com/Automattic/expect.js/issues/58

I set 0 as default for the parameter n in the length function.