### PR TITLE
Fix #81: expect return value can't be reused with .to.have.property

### DIFF
--- a/index.js
+++ b/index.js
@@ -394,7 +394,6 @@
           + ' of ' + i(val) });
     }
 
-    this.obj = this.obj[name];
     return this;
   };
 

--- a/test/expect.js
+++ b/test/expect.js
@@ -570,4 +570,9 @@ describe('expect', function () {
     }, "explicit failure with message");
   });
 
+  it('should not fail with duplicate to.have.property assertions', function () {
+    var y = expect({ a : 1, b : 2 });
+    y.to.have.property("a", 1);
+    y.to.have.property("b", 2);
+  });
 });


### PR DESCRIPTION
#81 

I removed this.obj update in to.have.property function, this should fix this.obj problem in reusing in subsequent assertions.